### PR TITLE
Simplify bundling executor schedule

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Contents:
    google.gax
    google.gax.auth
    google.gax.api_callable
+   google.gax.bundling
    google.gax.config
    google.gax.grpc
    google.gax.path_template

--- a/google/gax/__init__.py
+++ b/google/gax/__init__.py
@@ -64,7 +64,7 @@ class BundleDescriptor(
       request_descriminator_fields: a list of fields in the
         target request message class that are used to determine
         which messages should be bundled together.
-      subresponse_field: an optional field, when present it indicates field
+      subresponse_field: an optional field, when present it indicates the field
         in the response message that should be used to demultiplex the response
         into multiple response messages.
     """

--- a/google/gax/__init__.py
+++ b/google/gax/__init__.py
@@ -50,7 +50,8 @@ class BundleDescriptor(
         collections.namedtuple(
             'BundleDescriptor',
             ['bundled_field',
-             'request_descriminator_fields'])):
+             'request_descriminator_fields',
+             'subresponse_field'])):
     """Describes the structure of bundled call.
 
     request_descriminator_fields may include '.' as a separator, which is used
@@ -63,8 +64,19 @@ class BundleDescriptor(
       request_descriminator_fields: a list of fields in the
         target request message class that are used to determine
         which messages should be bundled together.
+      subresponse_field: an optional field, when present it indicates field
+        in the response message that should be used to demultiplex the response
+        into multiple response messages.
     """
-    pass
+    def __new__(cls,
+                bundled_field,
+                request_descriminator_fields,
+                subresponse_field=None):
+        return super(cls, BundleDescriptor).__new__(
+            cls,
+            bundled_field,
+            request_descriminator_fields,
+            subresponse_field)
 
 
 class BundleOptions(

--- a/google/gax/api_callable.py
+++ b/google/gax/api_callable.py
@@ -118,7 +118,8 @@ def _bundleable(a_func, desc, bundler):
     def inner(request):
         """Schedules execution of a bundling task."""
         the_id = bundling.compute_bundle_id(request, desc.discriminator_fields)
-        return bundler.schedule(a_func, the_id, desc.bundled_field, request)
+        return bundler.schedule(a_func, the_id, desc.bundled_field, request,
+                                subresponse_field=desc.subresponse_field)
 
     return inner
 
@@ -287,7 +288,6 @@ class ApiCallable(object):
             if timeout is None:
                 timeout = self.defaults.timeout
         return is_retrying, max_attempts, page_descriptor, timeout
-
 
     def __call__(self, *args, **kwargs):
         the_func = self.func

--- a/google/gax/api_callable.py
+++ b/google/gax/api_callable.py
@@ -118,8 +118,7 @@ def _bundleable(a_func, desc, bundler):
     def inner(request):
         """Schedules execution of a bundling task."""
         the_id = bundling.compute_bundle_id(request, desc.discriminator_fields)
-        return bundler.schedule(a_func, the_id, desc.bundled_field, request,
-                                subresponse_field=desc.subresponse_field)
+        return bundler.schedule(a_func, the_id, desc, request)
 
     return inner
 

--- a/google/gax/bundling.py
+++ b/google/gax/bundling.py
@@ -27,12 +27,31 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""Provides behavior that supports request bundling."""
+"""Provides behavior that supports request bundling.
+
+:func:`compute_bundle_id` is used generate ids linking API requests to the
+appropriate bundles.
+
+:class:`Event` is the result of scheduling a bundled api call.  It is a
+decorated :class:`threading.Event`; its ``wait`` and ``is_set`` methods
+are used wait for the bundle request to complete or determine if it has
+been completed respectively.
+
+:class:`Task` manages the sending of all the requests in a specific bundle.
+
+:class:`Executor` has a ``schedule`` method that is used add bundled api calls
+to a new or existing :class:`Task`.
+
+"""
 
 from __future__ import absolute_import
 
 import collections
+import copy
+import logging
 import threading
+
+_LOG = logging.getLogger(__name__)
 
 
 def _str_dotted_getattr(obj, name):
@@ -81,62 +100,131 @@ def compute_bundle_id(obj, descriminator_fields):
     return tuple(_str_dotted_getattr(obj, x) for x in descriminator_fields)
 
 
+_WARN_DEMUX_MISMATCH = ('cannot demultiplex the bundled response, got'
+                        ' %d subresponses; want %d, each bundled request will'
+                        ' receive all responses')
+
+
 class Task(object):
     """Coordinates the execution of a single bundle."""
 
-    def __init__(self, api_call, bundle_id, bundled_field, bundling_request):
+    def __init__(self, api_call, bundle_id, bundled_field, bundling_request,
+                 subresponse_field=None):
         """Constructor.
 
         Args:
            api_call (callable[[object], object]): the func that is this tasks's
              API call
-           bundle_id: the id of this bundle
-           bundled_field: the field used to create the bundled request
-           bundling_request: the request to pass as the arg to api_call
+           bundle_id (tuple): the id of this bundle
+           bundle_field (str): the field used to create the bundled request
+           bundling_request (object): the request to pass as the arg to api_call
+           subresponse_field (str): optional field used to demultiplex responses
 
         """
         self._api_call = api_call
         self._bundling_request = bundling_request
         self.bundle_id = bundle_id
         self.bundled_field = bundled_field
-        self.in_deque = collections.deque()
-        self.out_deque = collections.deque()
+        self.subresponse_field = subresponse_field
+        self._in_deque = collections.deque()
+        self._event_deque = collections.deque()
 
     @property
     def message_count(self):
         """The number of bundled messages."""
-        return len(self.in_deque)
+        return sum(len(msgs) for msgs in self._in_deque)
 
     @property
     def message_bytesize(self):
         """The size of in bytes of the bundle messages."""
-        return sum(len(str(x)) for x in self.in_deque)
+        return sum(len(str(m)) for msgs in self._in_deque for m in msgs)
 
     def run(self):
         """Call the task's func.
 
         The task's func will be called with the bundling requests func
         """
-        if len(self.in_deque) == 0:
+        if len(self._in_deque) == 0:
             return
         req = self._bundling_request
-        setattr(req, self.bundled_field, list(x for x in self.in_deque))
-        self.in_deque.clear()
+        setattr(req,
+                self.bundled_field,
+                [m for msgs in self._in_deque for m in msgs])
+
+        subresponse_field = self.subresponse_field
+        if subresponse_field:
+            self._run_with_subresponses(req, subresponse_field)
+        else:
+            self._run_with_no_subresponse(req)
+
+    def _run_with_no_subresponse(self, req):
         try:
             resp = self._api_call(req)
-            self.out_deque.append(resp)
+            for event in self._event_deque:
+                event.result = resp
+                event.set()
         except Exception as exc:  # pylint: disable=broad-except
-            self.out_deque.append(exc)
+            for event in self._event_deque:
+                event.result = exc
+                event.set()
+        finally:
+            self._in_deque.clear()
+            self._event_deque.clear()
+
+    def _run_with_subresponses(self, req, subresponse_field):
+        try:
+            resp = self._api_call(req)
+            in_sizes = [len(msgs) for msgs in self._in_deque]
+            all_subresponses = getattr(resp, subresponse_field)
+            if len(all_subresponses) != sum(in_sizes):
+                _LOG.warn(_WARN_DEMUX_MISMATCH, len(all_subresponses),
+                          sum(in_sizes))
+                for event in self._event_deque:
+                    event.result = resp
+                    event.set()
+            else:
+                start = 0
+                for i, event in zip(in_sizes, self._event_deque):
+                    next_copy = copy.copy(resp)
+                    subresponses = all_subresponses[start:start + i]
+                    setattr(next_copy, subresponse_field, subresponses)
+                    start += i
+                    event.result = next_copy
+                    event.set()
+        except Exception as exc:  # pylint: disable=broad-except
+            for event in self._event_deque:
+                event.result = exc
+                event.set()
+        finally:
+            self._in_deque.clear()
+            self._event_deque.clear()
 
     def extend(self, msgs):
-        """Adds msgs to the in_queue."""
-        self.in_deque.extend(msgs)
+        """Adds msgs to the tasks.
 
-    def canceller_for(self, msgs):
+        Args:
+           msgs: a iterable of messages that can be appended to the task's
+            bundle_field
+
+        Returns:
+           an :class:`Event` that can be used to wait on the response
+        """
+        self._in_deque.append(msgs)
+        event = self._event_for(msgs)
+        self._event_deque.append(event)
+        return event
+
+    def _event_for(self, msgs):
+        """Creates an Event that is set when the bundle with msgs is sent."""
+        event = Event()
+        event.canceller = self._canceller_for(msgs, event)
+        return event
+
+    def _canceller_for(self, msgs, event):
         """Obtains a cancellation function that removes msgs
 
 `        The returned cancellation function returns ``True`` if all messages
-        was removed successfully from the in_deque, and false if it was not.
+        was removed successfully from the _in_deque, and false if it was not.
 
 
         Args:
@@ -144,8 +232,7 @@ class Task(object):
 
         Returns:
            (callable[[], boolean]): used to remove the messages from the
-              in_deque
-
+              _in_deque
         """
 
         def canceller():
@@ -155,13 +242,12 @@ class Task(object):
                ``False`` if any of messages had already been sent, otherwise
                ``True``
             """
-            result = True
-            for msg in msgs:
-                try:
-                    self.in_deque.remove(msg)
-                except ValueError:
-                    result = False
-            return result
+            try:
+                self._event_deque.remove(event)
+                self._in_deque.remove(msgs)
+                return True
+            except ValueError:
+                return False
 
         return canceller
 
@@ -190,53 +276,51 @@ class Executor(object):
         self._task_lock = threading.RLock()
         self._timer = None
 
-    def schedule(self, api_call, bundle_id, bundled_field, bundling_request):
-        """Schedules ``bundled_msg`` to be sent in ``bundling_request``.
+    def schedule(self, api_call, bundle_id, bundle_desc, bundling_request):
+        """Schedules bundle_desc of bundling_request as part of bundle_id.
 
-        The returned value consists of two values, a collections.deque that will
-        contain the response and an optional callable([[],boolean]) that can be
-        used to cancel sending of this particular part of the bundle.
+        The returned value an :class:`Event` that
 
-        TODO: determine whether or not the deque to provide seperate responses
-        for each part of the bundle.
+        * has a ``result`` attribute that will eventually be set to the result
+          the api call
+        * will be used to wait for the response
+        * holds the canceller function for canceling this part of the bundle
 
         Args:
           api_call (callable[[object], object]): the scheduled API call
           bundle_id (str): identifies the bundle on which the API call should be
             made
-          bundled_field (str): the name of the field in bundling_request
+          bundle_desc (gax.BundleDescriptor): describes the structure of the
+            bundled call
           bundling_request (object): the request instance to use in the API call
 
         Returns:
-           tuple: (:class:`collections.deque`,
-                    callable([[], boolean]) )
-
+           an :class:`Event`
         """
-        bundle = self._bundle_for(api_call, bundle_id, bundled_field,
+        bundle = self._bundle_for(api_call, bundle_id, bundle_desc,
                                   bundling_request)
-        msgs = getattr(bundling_request, bundled_field)
-        bundle.extend(msgs)
+        msgs = getattr(bundling_request, bundle_desc.bundled_field)
+        event = bundle.extend(msgs)
 
         # Run the bundle if the count threshold was reached.
         count_threshold = self._options.message_count_threshold
         if count_threshold > 0 and bundle.message_count >= count_threshold:
             self._run_now(bundle.bundle_id)
-            return bundle.out_deque, None
 
         # Run the bundle if the size threshold was reached.
         size_threshold = self._options.message_bytesize_threshold
         if size_threshold > 0 and bundle.message_bytesize >= size_threshold:
             self._run_now(bundle.bundle_id)
-            return bundle.out_deque, None
 
-        return bundle.out_deque, bundle.canceller_for(msgs)
+        return event
 
-    def _bundle_for(self, api_call, bundle_id, bundled_field, bundling_request):
+    def _bundle_for(self, api_call, bundle_id, bundle_desc, bundling_request):
         with self._task_lock:
             bundle = self._tasks.get(bundle_id)
             if bundle is None:
-                bundle = Task(api_call, bundle_id, bundled_field,
-                              bundling_request)
+                bundle = Task(api_call, bundle_id, bundle_desc.bundled_field,
+                              bundling_request,
+                              subresponse_field=bundle_desc.subresponse_field)
                 delay_threshold = self._options.delay_threshold
                 if delay_threshold > 0:
                     self._run_later(bundle, delay_threshold)
@@ -258,3 +342,42 @@ class Executor(object):
             if bundle_id in self._tasks:
                 a_task = self._tasks.pop(bundle_id)
                 a_task.run()
+
+
+class Event(object):
+    """Wraps a threading.Event, adding, canceller and result attributes."""
+
+    def __init__(self):
+        """Constructor.
+
+        """
+        self._event = threading.Event()
+        self.result = None
+        self.canceller = None
+
+    def is_set(self):
+        """Calls ``is_set`` on the decorated :class:`threading.Event`."""
+        return self._event.is_set()
+
+    def set(self):
+        """Calls ``set`` on the decorated :class:`threading.Event`."""
+        return self._event.set()
+
+    def clear(self):
+        """Calls ``clear`` on the decorated :class:`threading.Event`.
+
+        Also resets the result if one has been set.
+        """
+        self.result = None
+        return self._event.clear()
+
+    def wait(self, timeout=None):
+        """Calls ``wait`` on the decorated :class:`threading.Event`."""
+        return self._event.wait(timeout=timeout)
+
+    def cancel(self):
+        """Invokes the cancellation function provided on construction."""
+        if self.canceller:
+            return self.canceller()
+        else:
+            return False


### PR DESCRIPTION
- Adds bundling.Event that wraps a threading.Event
  * this allows notification on request completion using the
    methods of threading.Event

- bundling.Event provides additional behaviour
  * it holds the cancellation function and result as attributes
  * the result holds the per-bundle-call result
  * this means callers no longer need to hold the out_deque

- this simplifies bundling.Executor#schedule; this is update to
  just return a bundling.Event

- Adds an optional subresponse field to BundleDescriptor
- Adds supports for this to Task#run
  * when the subresponse_field is present, the response is demultiplexed