### PR TITLE
Restrict literal regex according to RFC spec

### DIFF
--- a/google/gax/path_template.py
+++ b/google/gax/path_template.py
@@ -190,7 +190,7 @@ class _Parser(object):
     t_EQUALS = r'='
     t_WILDCARD = r'\*'
     t_PATH_WILDCARD = r'\*\*'
-    t_LITERAL = r'[^/}{=\*]+'
+    t_LITERAL = r'[a-zA-Z0-9\._~-]+'
 
     t_ignore = ' \t'
 
@@ -199,7 +199,7 @@ class _Parser(object):
 
     def __init__(self):
         self.lexer = lex.lex(module=self)
-        self.parser = yacc.yacc(module=self, debug=0, write_tables=0)
+        self.parser = yacc.yacc(module=self, debug=False, write_tables=False)
 
     def parse(self, data):
         """Returns a list of path template segments parsed from data.
@@ -288,3 +288,8 @@ class _Parser(object):
                 'parser error: unexpected token \'%s\'' % p.type)
         else:
             raise ValidationException('parser error: unexpected EOF')
+
+    def t_error(self, t):
+        """Raises a lexer error."""
+        raise ValidationException(
+            'lexer error: illegal character \'%s\'' % t.value[0])

--- a/test/test_path_template.py
+++ b/test/test_path_template.py
@@ -42,6 +42,10 @@ class TestPathTemplate(unittest2.TestCase):
     def test_len(self):
         self.assertEqual(len(PathTemplate('a/b/**/*/{a=hello/world}')), 6)
 
+    def test_fail_invalid_token(self):
+        self.assertRaises(ValidationException,
+                          PathTemplate, 'hello/wor@ld')
+
     def test_fail_when_impossible_match(self):
         template = PathTemplate('hello/world')
         self.assertRaises(ValidationException,
@@ -119,5 +123,5 @@ class TestPathTemplate(unittest2.TestCase):
         self.assertEqual(str(template), 'buckets/{hello=*}')
         template = PathTemplate('/buckets/{hello=what}/{world}')
         self.assertEqual(str(template), 'buckets/{hello=what}/{world=*}')
-        template = PathTemplate('/buckets/hello?#$##:what')
-        self.assertEqual(str(template), 'buckets/hello?#$##:what')
+        template = PathTemplate('/buckets/helloazAZ09-.~_:what')
+        self.assertEqual(str(template), 'buckets/helloazAZ09-.~_:what')


### PR DESCRIPTION
Add t_error to catch illegal token exceptions.