### PR TITLE
Rename bundling fields

### DIFF
--- a/google/gax/__init__.py
+++ b/google/gax/__init__.py
@@ -206,7 +206,7 @@ class BundleDescriptor(
 
     Attributes:
       bundled_field: the repeated field in the request message that
-        will have its messages aggregated by bundling
+        will have its elements aggregated by bundling
       request_discriminator_fields: a list of fields in the
         target request message class that are used to determine
         which messages should be bundled together.
@@ -228,8 +228,8 @@ class BundleDescriptor(
 class BundleOptions(
         collections.namedtuple(
             'BundleOptions',
-            ['message_count_threshold',
-             'message_bytesize_threshold',
+            ['element_count_threshold',
+             'request_byte_threshold',
              'delay_threshold'])):
     """Holds values used to configure bundling.
 
@@ -237,19 +237,23 @@ class BundleOptions(
     should be made.
 
     Attributes:
-        message_count_threshold: the bundled request will be sent once
-            the count of outstanding messages reaches this value
-        message_bytesize_threshold: the bundled request will be sent once
-            the count of bytes in the outstanding messages reaches this value
+        element_count_threshold: the bundled request will be sent once the
+          count of outstanding elements in the repeated field reaches this
+          value.
+        request_byte_threshold: the bundled request will be sent once the count
+          of bytes in the request reaches this value. Note that this value is
+          pessimistically approximated by summing the bytesizes of the elements
+          in the repeated field, with a buffer applied to compensate for the
+          corresponding under-approximation.
         delay_threshold: the bundled request will be sent this amount of
-            time after the first message in the bundle was added to it.
+          time after the first element in the bundle was added to it.
 
     """
     # pylint: disable=too-few-public-methods
 
     def __new__(cls,
-                message_count_threshold=0,
-                message_bytesize_threshold=0,
+                element_count_threshold=0,
+                request_byte_threshold=0,
                 delay_threshold=0):
         """Invokes the base constructor with default values.
 
@@ -257,23 +261,27 @@ class BundleOptions(
         specify at least one valid threshold value during construction.
 
         Args:
-           message_count_threshold: the bundled request will be sent once
-             the count of outstanding messages reaches this value
-           message_bytesize_threshold: the bundled request will be sent once
-             the count of bytes in the outstanding messages reaches this value
+           element_count_threshold: the bundled request will be sent once the
+             count of outstanding elements in the repeated field reaches this
+             value.
+           request_byte_threshold: the bundled request will be sent once the count
+             of bytes in the request reaches this value. Note that this value is
+             pessimistically approximated by summing the bytesizes of the elements
+             in the repeated field, with a buffer applied to compensate for the
+             corresponding under-approximation.
            delay_threshold: the bundled request will be sent this amount of
-              time after the first message in the bundle was added to it.
+             time after the first element in the bundle was added to it.
 
         """
-        assert isinstance(message_count_threshold, int), 'should be an int'
-        assert isinstance(message_bytesize_threshold, int), 'should be an int'
+        assert isinstance(element_count_threshold, int), 'should be an int'
+        assert isinstance(request_byte_threshold, int), 'should be an int'
         assert isinstance(delay_threshold, int), 'should be an int'
-        assert (message_bytesize_threshold > 0 or
-                message_count_threshold > 0 or
+        assert (element_count_threshold > 0 or
+                request_byte_threshold > 0 or
                 delay_threshold > 0), 'one threshold should be > 0'
 
         return super(cls, BundleOptions).__new__(
             cls,
-            message_count_threshold,
-            message_bytesize_threshold,
+            element_count_threshold,
+            request_byte_threshold,
             delay_threshold)

--- a/test/test_api_callable.py
+++ b/test/test_api_callable.py
@@ -66,7 +66,7 @@ _CONFIG = {
             'retry_codes_name': 'foo_retry',
             'retry_params_name': 'default',
             'bundle_options': {
-                'message_count_threshold': 6},
+                'element_count_threshold': 6},
             'bundle_descriptor': {
                 'bundled_field': 'abc',
                 'request_discriminator_fields': []}
@@ -180,14 +180,14 @@ class TestApiCallable(unittest2.TestCase):
     def test_bundling(self):
         # pylint: disable=abstract-method, too-few-public-methods
         class BundlingRequest(object):
-            def __init__(self, messages=None):
-                self.messages = messages
+            def __init__(self, elements=None):
+                self.elements = elements
 
-        fake_grpc_func_descriptor = BundleDescriptor('messages', [])
-        bundler = bundling.Executor(BundleOptions(message_count_threshold=8))
+        fake_grpc_func_descriptor = BundleDescriptor('elements', [])
+        bundler = bundling.Executor(BundleOptions(element_count_threshold=8))
 
         def my_func(request, dummy_timeout):
-            return len(request.messages)
+            return len(request.elements)
 
         settings = CallSettings(
             bundler=bundler, bundle_descriptor=fake_grpc_func_descriptor,

--- a/test/test_gax.py
+++ b/test/test_gax.py
@@ -48,10 +48,10 @@ class TestBundleOptions(unittest2.TestCase):
         not_an_int = 'i am a string'
         self.assertRaises(AssertionError,
                           BundleOptions,
-                          message_count_threshold=not_an_int)
+                          element_count_threshold=not_an_int)
         self.assertRaises(AssertionError,
                           BundleOptions,
-                          message_bytesize_threshold=not_an_int)
+                          request_byte_threshold=not_an_int)
         self.assertRaises(AssertionError,
                           BundleOptions,
                           delay_threshold=not_an_int)


### PR DESCRIPTION
Clarifies whether "message" is used in the sense of an element in a
repeated field, or in the sense of a proto message; also brings
terminology in line with code generator terminology.

Note: I have attempted to use term "element" to refer to a generic
member of a repeated field, but certain specific elements _may_ be
messages as well (e.g., in pubsub) so I do not see the presence of
both terms in the `test_bundling` module to be contradictory.

Fixes #36 