### PR TITLE
Increase usefulness of a PathTemplate error; fix retrying bug

### DIFF
--- a/google/gax/api_callable.py
+++ b/google/gax/api_callable.py
@@ -393,7 +393,7 @@ class ApiCallable(object):
 
         # Note that the retrying decorator handles timeouts; otherwise, it
         # explicit partial application of the timeout argument is required.
-        if self.settings.retry:
+        if self.settings.retry and self.settings.retry.retry_codes:
             the_func = _retryable(the_func, self.settings.retry)
         else:
             the_func = _add_timeout_arg(the_func, self.settings.timeout)

--- a/google/gax/path_template.py
+++ b/google/gax/path_template.py
@@ -151,7 +151,9 @@ class PathTemplate(object):
             elif this[i].kind == _BINDING:
                 current_var = this[i].literal
         if j != len(that) or j != segment_count:
-            raise ValidationException('match error: impossible match')
+            raise ValidationException(
+                'match error: could not instantiate a path template from: {}'
+                .format(path))
         return bindings
 
 

--- a/test/test_api_callable.py
+++ b/test/test_api_callable.py
@@ -130,6 +130,19 @@ class TestApiCallable(unittest2.TestCase):
         self.assertEqual(mock_call.call_count, to_attempt)
 
     @mock.patch('time.time')
+    def test_no_retry_if_no_codes(self, mock_time):
+        retry = RetryOptions([], BackoffSettings(1, 2, 3, 4, 5, 6, 7))
+
+        mock_call = mock.Mock()
+        mock_call.side_effect = CustomException('', _FAKE_STATUS_CODE_1)
+        mock_time.return_value = 0
+
+        settings = CallSettings(timeout=0, retry=retry)
+        my_callable = api_callable.ApiCallable(mock_call, settings)
+        self.assertRaises(CustomException, my_callable, None)
+        self.assertEqual(mock_call.call_count, 1)
+
+    @mock.patch('time.time')
     @mock.patch('google.gax.config.exc_to_code')
     def test_retry_aborts_simple(self, mock_exc_to_code, mock_time):
         def fake_call(dummy_request, dummy_timeout):


### PR DESCRIPTION
Replaced "impossible match" by actual description of the error.

Also fixes #51 (a retrying bug).