### PR TITLE
Recognize ExpirationError, even if no status code

### DIFF
--- a/google/gax/__init__.py
+++ b/google/gax/__init__.py
@@ -33,7 +33,7 @@ from __future__ import absolute_import
 import collections
 
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'
 
 
 OPTION_INHERIT = object()

--- a/google/gax/config.py
+++ b/google/gax/config.py
@@ -40,6 +40,8 @@ def exc_to_code(exc):
     """Retrieves the status code from an exception"""
     if not isinstance(exc, face.AbortionError):
         return None
+    elif isinstance(exc, face.ExpirationError):
+        return StatusCode.DEADLINE_EXCEEDED
     else:
         return getattr(exc, 'code', None)
 


### PR DESCRIPTION
ExpirationError sometimes seems to have no status code; force it
to map to DEADLINE_EXCEEDED.

fixes #53 