### PR TITLE
Do not require descriptors for construct_settings

### DIFF
--- a/google/gax/__init__.py
+++ b/google/gax/__init__.py
@@ -33,7 +33,7 @@ from __future__ import absolute_import
 import collections
 
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 
 
 OPTION_INHERIT = object()

--- a/google/gax/api_callable.py
+++ b/google/gax/api_callable.py
@@ -274,8 +274,8 @@ def _construct_retry(
 
 
 def construct_settings(
-        service_name, client_config, bundle_descriptors, page_descriptors,
-        bundling_override, retry_override, retry_names, timeout):
+        service_name, client_config, bundling_override, retry_override,
+        retry_names, timeout, bundle_descriptors=None, page_descriptors=None):
     """Constructs a dictionary mapping method names to CallSettings.
 
     The ``client_config`` parameter is parsed from a client configuration JSON
@@ -341,6 +341,8 @@ def construct_settings(
       timeout: The timeout parameter for all API calls in this dictionary.
     """
     defaults = dict()
+    bundle_descriptors = bundle_descriptors or {}
+    page_descriptors = page_descriptors or {}
 
     try:
         service_config = client_config['interfaces'][service_name]

--- a/test/test_api_callable.py
+++ b/test/test_api_callable.py
@@ -328,8 +328,9 @@ class TestApiCallable(unittest2.TestCase):
 
     def test_construct_settings(self):
         defaults = api_callable.construct_settings(
-            _SERVICE_NAME, _A_CONFIG, _BUNDLE_DESCRIPTORS, _PAGE_DESCRIPTORS,
-            dict(), dict(), _RETRY_DICT, 30)
+            _SERVICE_NAME, _A_CONFIG, dict(), dict(), _RETRY_DICT, 30,
+            bundle_descriptors=_BUNDLE_DESCRIPTORS,
+            page_descriptors=_PAGE_DESCRIPTORS)
         settings = defaults['bundling_method']
         self.assertEquals(settings.timeout, 30)
         self.assertIsInstance(settings.bundler, bundling.Executor)
@@ -347,8 +348,9 @@ class TestApiCallable(unittest2.TestCase):
         _bundling_override = {'bundling_method': None}
         _retry_override = {'page_streaming_method': None}
         defaults = api_callable.construct_settings(
-            _SERVICE_NAME, _A_CONFIG, _BUNDLE_DESCRIPTORS, _PAGE_DESCRIPTORS,
-            _bundling_override, _retry_override, _RETRY_DICT, 30)
+            _SERVICE_NAME, _A_CONFIG, _bundling_override, _retry_override,
+            _RETRY_DICT, 30, bundle_descriptors=_BUNDLE_DESCRIPTORS,
+            page_descriptors=_PAGE_DESCRIPTORS)
         settings = defaults['bundling_method']
         self.assertEquals(settings.timeout, 30)
         self.assertIsNone(settings.bundler)


### PR DESCRIPTION
Changes the descriptors from required to optional parameters to
`construct_settings`. This is nicer for APIs that either do not
support page streaming or bundling.