### PR TITLE
Refactor: replace ApiCallable with a function

### DIFF
--- a/google/gax/__init__.py
+++ b/google/gax/__init__.py
@@ -33,7 +33,7 @@ from __future__ import absolute_import
 import collections
 
 
-__version__ = '0.7.1'
+__version__ = '0.8.0'
 
 
 OPTION_INHERIT = object()


### PR DESCRIPTION
- replaces the ApiCallable class with a decorator-style function that
  does the same thing