### PR TITLE
Convert CamelCase method name to snake_case

### DIFF
--- a/google/gax/__init__.py
+++ b/google/gax/__init__.py
@@ -33,7 +33,7 @@ from __future__ import absolute_import
 import collections
 
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'
 
 
 OPTION_INHERIT = object()

--- a/test/test_api_callable.py
+++ b/test/test_api_callable.py
@@ -62,7 +62,8 @@ _A_CONFIG = {
                 }
             },
             'methods': {
-                'bundling_method': {
+                # Note that GAX should normalize this to snake case
+                'BundlingMethod': {
                     'retry_codes_name': 'foo_retry',
                     'retry_params_name': 'default',
                     'bundling': {


### PR DESCRIPTION
The currently, the code generator uses Guava's CaseFormat to convert
the CamelCase method names defined in the IDL to more Pythonic
snake_case. However, this conversion is not reflected in the client
config, since that config is language-independent. Instead, we have
GAX do the conversion in a format that is intended to match the Guava
case formatting exactly.

(Note that it is necessary for Guava CaseFormat and GAX to provide
identical behavior, or else the client config will not be parsed
properly.)

Fixes #73.