### PR TITLE
Fix BundleOptions construction

### DIFF
--- a/google/gax/__init__.py
+++ b/google/gax/__init__.py
@@ -33,7 +33,7 @@ from __future__ import absolute_import
 import collections
 
 
-__version__ = '0.9.1'
+__version__ = '0.9.2'
 
 
 OPTION_INHERIT = object()

--- a/google/gax/api_callable.py
+++ b/google/gax/api_callable.py
@@ -112,7 +112,7 @@ def _retryable(a_func, retry):
                 if config.exc_to_code(exception) not in retry.retry_codes:
                     raise RetryError(
                         'Exception occurred in retry method that was not'
-                        'classified as transient', exception)
+                        ' classified as transient', exception)
 
                 # pylint: disable=redefined-variable-type
                 exc = RetryError('Retry total timeout exceeded with exception',

--- a/google/gax/api_callable.py
+++ b/google/gax/api_callable.py
@@ -214,8 +214,14 @@ def _construct_bundling(method_config, method_bundling_override,
     if 'bundling' in method_config and bundle_descriptor:
 
         if method_bundling_override == OPTION_INHERIT:
+            params = method_config['bundling']
             bundler = bundling.Executor(BundleOptions(
-                **method_config['bundling']))
+                element_count_threshold=params.get(
+                    'element_count_threshold', 0),
+                element_count_limit=params.get('element_count_limit', 0),
+                request_byte_threshold=params.get('request_byte_threshold', 0),
+                request_byte_limit=params.get('request_byte_limit', 0),
+                delay_threshold=params.get('delay_threshold_millis', 0)))
         elif method_bundling_override:
             bundler = bundling.Executor(method_bundling_override)
         else:


### PR DESCRIPTION
Our field names in Python differ slightly from the JSON config names.