### PR TITLE
Disable bundling by default, fix bundling bug

### DIFF
--- a/google/gax/__init__.py
+++ b/google/gax/__init__.py
@@ -33,7 +33,7 @@ from __future__ import absolute_import
 import collections
 
 
-__version__ = '0.9.4'
+__version__ = '0.10.0'
 
 
 OPTION_INHERIT = object()
@@ -102,9 +102,14 @@ class CallSettings(object):
             else:
                 page_descriptor = None
 
+            if options.is_bundling:
+                bundler = self.bundler
+            else:
+                bundler = None
+
             return CallSettings(
                 timeout=timeout, retry=retry,
-                page_descriptor=page_descriptor, bundler=self.bundler,
+                page_descriptor=page_descriptor, bundler=bundler,
                 bundle_descriptor=self.bundle_descriptor)
 
 
@@ -116,11 +121,10 @@ class CallOptions(object):
 
     When provided, its values override the GAX service defaults for that
     particular call.
-
     """
     # pylint: disable=too-few-public-methods
     def __init__(self, timeout=OPTION_INHERIT, retry=OPTION_INHERIT,
-                 is_page_streaming=OPTION_INHERIT):
+                 is_page_streaming=OPTION_INHERIT, is_bundling=False):
         """Constructor.
 
         Example:
@@ -132,6 +136,9 @@ class CallOptions(object):
            >>>
            >>> # disable retrying on an api call that normally retries
            >>> o3 = CallOptions(retry=None)
+           >>>
+           >>> # enable bundling on a call that supports it
+           >>> o4 = CallOptions(is_bundling=True)
 
         Args:
             timeout (int): The client-side timeout for API calls.
@@ -139,10 +146,13 @@ class CallOptions(object):
               on transient errors. When set to None, the call will not retry.
             is_page_streaming (bool): If set and the call is configured for page
               streaming, page streaming is performed.
+            is_bundling (bool): If set and the call is configured for bundling,
+              bundling is performed. Bundling is always disabled by default.
         """
         self.timeout = timeout
         self.retry = retry
         self.is_page_streaming = is_page_streaming
+        self.is_bundling = is_bundling
 
 
 class PageDescriptor(

--- a/google/gax/bundling.py
+++ b/google/gax/bundling.py
@@ -150,9 +150,9 @@ class Task(object):
         if len(self._in_deque) == 0:
             return
         req = self._bundling_request
-        setattr(req,
-                self.bundled_field,
-                [e for elts in self._in_deque for e in elts])
+        del getattr(req, self.bundled_field)[:]
+        getattr(req, self.bundled_field).extend(
+            [e for elts in self._in_deque for e in elts])
 
         subresponse_field = self.subresponse_field
         if subresponse_field:
@@ -212,6 +212,10 @@ class Task(object):
         Returns:
            an :class:`Event` that can be used to wait on the response.
         """
+        # Use a copy, not a reference, as it is later necessary to mutate
+        # the proto field from which elts are drawn in order to construct
+        # the bundled request.
+        elts = elts[:]
         self._in_deque.append(elts)
         event = self._event_for(elts)
         self._event_deque.append(event)

--- a/test/test_bundling.py
+++ b/test/test_bundling.py
@@ -135,7 +135,7 @@ def _make_a_test_task(api_call=_return_request):
         api_call,
         'an_id',
         'field1',
-        _Simple('dummy_value'),
+        _Simple([]),
         dict())
 
 


### PR DESCRIPTION
- Add `is_bundling` field to CallOptions. This field is False by
  default and must be explicitly enabled for a call to bundle.
- Fix a bug (#91) where proto repeated field was assigned to instead of
  extended; proto does not support repeated field assignment.