### PR TITLE
Update construct_settings overrides

### DIFF
--- a/google/gax/__init__.py
+++ b/google/gax/__init__.py
@@ -33,7 +33,7 @@ from __future__ import absolute_import
 import collections
 
 
-__version__ = '0.10.2'
+__version__ = '0.11.0'
 
 
 INITIAL_PAGE = object()

--- a/google/gax/api_callable.py
+++ b/google/gax/api_callable.py
@@ -239,7 +239,7 @@ def _construct_retry(method_config, retry_codes, retry_params, retry_names):
       method_config: A dictionary representing a single ``methods`` entry of the
         standard API client config file. (See ``construct_settings()`` for
         information on this yaml.)
-      retry_codes_def: A dictionary parsed from the ``retry_codes_def`` entry
+      retry_codes: A dictionary parsed from the ``retry_codes`` entry
         of the standard API client config file. (See ``construct_settings()``
         for information on this yaml.)
       retry_params: A dictionary parsed from the ``retry_params`` entry
@@ -272,16 +272,15 @@ def _construct_retry(method_config, retry_codes, retry_params, retry_names):
 
 
 def _merge_retry_options(retry, overrides):
-    """Helper fo ``construct_settings()``.
+    """Helper for ``construct_settings()``.
 
-    This takes two retry options, and merges them into a single RetryOption
-    instance.
+    Takes two retry options, and merges them into a single RetryOption instance.
 
     Args:
       retry: The base RetryOptions.
       overrides: The RetryOptions used for overriding ``retry``. Use the values
-        if it is not None. If entire ``overrides`` is None, that means cancel of
-        specifying retry options, thus returns None.
+        if it is not None. If entire ``overrides`` is None, ignore the base
+        retry and return None.
 
     Returns:
       The merged RetryOptions, or None if it will be canceled.
@@ -289,7 +288,7 @@ def _merge_retry_options(retry, overrides):
     if overrides is None:
         return None
 
-    if (overrides.retry_codes is None and overrides.backoff_settings is None):
+    if overrides.retry_codes is None and overrides.backoff_settings is None:
         return retry
 
     codes = retry.retry_codes
@@ -386,7 +385,7 @@ def construct_settings(
         located in the provided ``client_config``.
     """
     # pylint: disable=too-many-locals
-    defaults = dict()
+    defaults = {}
     bundle_descriptors = bundle_descriptors or {}
     page_descriptors = page_descriptors or {}
 

--- a/test/test_api_callable.py
+++ b/test/test_api_callable.py
@@ -71,7 +71,7 @@ _A_CONFIG = {
                         'element_count_limit': 10
                     }
                 },
-                'page_streaming_method': {
+                'PageStreamingMethod': {
                     'retry_codes_name': 'bar_retry',
                     'retry_params_name': 'default'
                 }
@@ -366,7 +366,7 @@ class TestCreateApiCallable(unittest2.TestCase):
 
     def test_construct_settings(self):
         defaults = api_callable.construct_settings(
-            _SERVICE_NAME, _A_CONFIG, dict(), dict(), _RETRY_DICT, 30,
+            _SERVICE_NAME, _A_CONFIG, dict(), _RETRY_DICT, 30,
             bundle_descriptors=_BUNDLE_DESCRIPTORS,
             page_descriptors=_PAGE_DESCRIPTORS)
         settings = defaults['bundling_method']
@@ -383,11 +383,21 @@ class TestCreateApiCallable(unittest2.TestCase):
         self.assertIsInstance(settings.retry, RetryOptions)
 
     def test_construct_settings_override(self):
-        _bundling_override = {'bundling_method': None}
-        _retry_override = {'page_streaming_method': None}
+        _override = {
+            'interfaces': {
+                _SERVICE_NAME: {
+                    'methods': {
+                        'PageStreamingMethod': None,
+                        'BundlingMethod': {
+                            'bundling': None
+                        }
+                    }
+                }
+            }
+        }
         defaults = api_callable.construct_settings(
-            _SERVICE_NAME, _A_CONFIG, _bundling_override, _retry_override,
-            _RETRY_DICT, 30, bundle_descriptors=_BUNDLE_DESCRIPTORS,
+            _SERVICE_NAME, _A_CONFIG, _override, _RETRY_DICT, 30,
+            bundle_descriptors=_BUNDLE_DESCRIPTORS,
             page_descriptors=_PAGE_DESCRIPTORS)
         settings = defaults['bundling_method']
         self.assertEquals(settings.timeout, 30)
@@ -397,6 +407,60 @@ class TestCreateApiCallable(unittest2.TestCase):
         self.assertEquals(settings.timeout, 30)
         self.assertIsInstance(settings.page_descriptor, PageDescriptor)
         self.assertIsNone(settings.retry)
+
+    def test_construct_settings_override2(self):
+        _override = {
+            'interfaces': {
+                _SERVICE_NAME: {
+                    'retry_codes': {
+                        'foo_retry': [],
+                        'baz_retry': ['code_a']
+                    },
+                    'retry_params': {
+                        'default': {
+                            'initial_retry_delay_millis': 200,
+                            'retry_delay_multiplier': 1.5
+                        },
+                        '10x': {
+                            'initial_retry_delay_millis': 1000,
+                            'retry_delay_multiplier': 1.2,
+                            'max_retry_delay_millis': 10000,
+                            'initial_rpc_timeout_millis': 3000,
+                            'rpc_timeout_multiplier': 1.3,
+                            'max_rpc_timeout_millis': 30000,
+                            'total_timeout_millis': 300000
+                        },
+                    },
+                    'methods': {
+                        'PageStreamingMethod': {
+                            'retry_codes_name': 'baz_retry'
+                        },
+                        'BundlingMethod': {
+                            'retry_params_name': '10x',
+                            'bundling': {
+                                'element_count_limit': 20
+                            }
+                        },
+                    }
+                }
+            }
+        }
+        defaults = api_callable.construct_settings(
+            _SERVICE_NAME, _A_CONFIG, _override, _RETRY_DICT, 30,
+            bundle_descriptors=_BUNDLE_DESCRIPTORS,
+            page_descriptors=_PAGE_DESCRIPTORS)
+        settings = defaults['bundling_method']
+        backoff = settings.retry.backoff_settings
+        self.assertEquals(backoff.initial_retry_delay_millis, 1000)
+        self.assertEquals(settings.retry.retry_codes, [])
+        self.assertIsInstance(settings.bundler, bundling.Executor)
+        self.assertIsInstance(settings.bundle_descriptor, BundleDescriptor)
+        settings = defaults['page_streaming_method']
+        backoff = settings.retry.backoff_settings
+        self.assertEquals(backoff.initial_retry_delay_millis, 200)
+        self.assertEquals(backoff.retry_delay_multiplier, 1.5)
+        self.assertEquals(backoff.max_retry_delay_millis, 1000)
+        self.assertEquals(settings.retry.retry_codes, [_RETRY_DICT['code_a']])
 
     @mock.patch('google.gax.config.API_ERRORS', (CustomException, ))
     def test_catch_error(self):

--- a/test/test_api_callable.py
+++ b/test/test_api_callable.py
@@ -447,7 +447,7 @@ class TestCreateApiCallable(unittest2.TestCase):
         self.assertIsInstance(settings.bundler, bundling.Executor)
         self.assertIsInstance(settings.bundle_descriptor, BundleDescriptor)
 
-        # page_streaming_method is unaffectd because it's not specified in
+        # page_streaming_method is unaffected because it's not specified in
         # overrides. 'bar_retry' or 'default' definitions in overrides should
         # not affect the methods which are not in the overrides.
         settings = defaults['page_streaming_method']

--- a/test/test_api_callable.py
+++ b/test/test_api_callable.py
@@ -386,25 +386,9 @@ class TestCreateApiCallable(unittest2.TestCase):
         _override = {
             'interfaces': {
                 _SERVICE_NAME: {
-                    'retry_codes': {
-                        'foo_retry': ['code_a', 'code_b'],
-                    },
-                    'retry_params': {
-                        'default': {
-                            'initial_retry_delay_millis': 100,
-                            'retry_delay_multiplier': 1.2,
-                            'max_retry_delay_millis': 1000,
-                            'initial_rpc_timeout_millis': 300,
-                            'rpc_timeout_multiplier': 1.3,
-                            'max_rpc_timeout_millis': 3000,
-                            'total_timeout_millis': 30000
-                        }
-                    },
                     'methods': {
                         'PageStreamingMethod': None,
                         'BundlingMethod': {
-                            'retry_codes_name': 'foo_retry',
-                            'retry_params_name': 'default',
                             'bundling': None
                         }
                     }
@@ -460,7 +444,8 @@ class TestCreateApiCallable(unittest2.TestCase):
         backoff = settings.retry.backoff_settings
         self.assertEquals(backoff.initial_retry_delay_millis, 1000)
         self.assertEquals(settings.retry.retry_codes, [_RETRY_DICT['code_a']])
-        self.assertIsNone(settings.bundler)
+        self.assertIsInstance(settings.bundler, bundling.Executor)
+        self.assertIsInstance(settings.bundle_descriptor, BundleDescriptor)
 
         # page_streaming_method is unaffectd because it's not specified in
         # overrides. 'bar_retry' or 'default' definitions in overrides should


### PR DESCRIPTION
Based on the discussion of #95 and googleapis/toolkit#70 --
this changes the interface of construct_settings a bit.

The new interface does not have the override parameters for
retrying and bundling anymore. Instead, it has a single
config_override that has the same strucure as client_config has.

API users can specify a copy of default config data with a few
modifications, but if the user-supplied config does not specify
some data, this will fall back to the default config, so
users can safely supply a part of the client config, just for
their edits.