### PR TITLE
Bug fix for page streaming

### DIFF
--- a/google/gax/__init__.py
+++ b/google/gax/__init__.py
@@ -33,7 +33,7 @@ from __future__ import absolute_import
 import collections
 
 
-__version__ = '0.12.4'
+__version__ = '0.12.5'
 
 
 INITIAL_PAGE = object()
@@ -420,7 +420,7 @@ class PageIterator(object):
           A PageIterator object.
         """
         self.response = None
-        self.page_token = page_token
+        self.page_token = page_token or INITIAL_PAGE
         self._func = api_call
         self._page_descriptor = page_descriptor
         self._request = request

--- a/test/test_api_callable.py
+++ b/test/test_api_callable.py
@@ -301,7 +301,7 @@ class TestCreateApiCallable(unittest2.TestCase):
             'page_token', 'next_page_token', 'nums')
 
         def grpc_return_value(request, *dummy_args, **dummy_kwargs):
-            start = int(request.page_token) if request.page_token else 0
+            start = int(request.page_token)
             if start > 0 and start < page_size * pages_to_stream:
                 return PageStreamingResponse(
                     nums=list(range(start,


### PR DESCRIPTION
\#107 means that `page_token` can sometimes be set to `None` instead
of `INITIAL_PAGE` when making the first call. This results in a
protobuf type error.