### PR TITLE
Make _CallSettings private

### DIFF
--- a/google/gax/__init__.py
+++ b/google/gax/__init__.py
@@ -48,7 +48,7 @@ CallOptions belongs will attempt to inherit that field from its default
 settings."""
 
 
-class CallSettings(object):
+class _CallSettings(object):
     """Encapsulates the call settings for an API call."""
     # pylint: disable=too-few-public-methods
     def __init__(self, timeout=30, retry=None, page_descriptor=None,
@@ -94,10 +94,10 @@ class CallSettings(object):
         return self.page_token is None
 
     def merge(self, options):
-        """Returns a new CallSettings merged from this and a CallOptions object.
+        """Returns new _CallSettings merged from this and a CallOptions object.
 
         Note that passing if the CallOptions instance specifies a page_token,
-        the merged CallSettings will have ``flatten_pages`` disabled. This
+        the merged _CallSettings will have ``flatten_pages`` disabled. This
         permits toggling per-resource/per-page page streaming.
 
         Args:
@@ -106,10 +106,10 @@ class CallSettings(object):
               object
 
         Returns:
-            A :class:`CallSettings` object.
+            A :class:`_CallSettings` object.
         """
         if not options:
-            return CallSettings(
+            return _CallSettings(
                 timeout=self.timeout, retry=self.retry,
                 page_descriptor=self.page_descriptor,
                 page_token=self.page_token,
@@ -142,7 +142,7 @@ class CallSettings(object):
                 kwargs = self.kwargs.copy()
                 kwargs.update(options.kwargs)
 
-            return CallSettings(
+            return _CallSettings(
                 timeout=timeout, retry=retry,
                 page_descriptor=self.page_descriptor, page_token=page_token,
                 bundler=bundler, bundle_descriptor=self.bundle_descriptor,

--- a/google/gax/api_callable.py
+++ b/google/gax/api_callable.py
@@ -35,7 +35,7 @@ import time
 
 from future import utils
 
-from . import (BackoffSettings, BundleOptions, bundling, CallSettings, config,
+from . import (BackoffSettings, BundleOptions, bundling, _CallSettings, config,
                PageIterator, ResourceIterator, RetryOptions)
 from .errors import GaxError, RetryError
 
@@ -301,7 +301,7 @@ def construct_settings(
         service_name, client_config, config_override,
         retry_names, bundle_descriptors=None, page_descriptors=None,
         kwargs=None):
-    """Constructs a dictionary mapping method names to CallSettings.
+    """Constructs a dictionary mapping method names to _CallSettings.
 
     The ``client_config`` parameter is parsed from a client configuration JSON
     file of the form:
@@ -406,7 +406,7 @@ def construct_settings(
             _construct_retry(overriding_method, overrides.get('retry_codes'),
                              overrides.get('retry_params'), retry_names))
 
-        defaults[snake_name] = CallSettings(
+        defaults[snake_name] = _CallSettings(
             timeout=timeout, retry=retry,
             page_descriptor=page_descriptors.get(snake_name),
             bundler=bundler, bundle_descriptor=bundle_descriptor,
@@ -452,7 +452,7 @@ def create_api_call(func, settings):
 
     Args:
       func (callable[[object], object]): is used to make a bare rpc call
-      settings (:class:`CallSettings`): provides the settings for this call
+      settings (:class:`_CallSettings`): provides the settings for this call
 
     Returns:
       func (callable[[object], object]): a bound method on a request stub used

--- a/test/test_gax.py
+++ b/test/test_gax.py
@@ -35,7 +35,7 @@ from __future__ import absolute_import
 import unittest2
 
 from google.gax import (
-    BundleOptions, CallOptions, CallSettings, INITIAL_PAGE, OPTION_INHERIT,
+    BundleOptions, CallOptions, _CallSettings, INITIAL_PAGE, OPTION_INHERIT,
     RetryOptions)
 
 
@@ -72,7 +72,7 @@ class TestCallSettings(unittest2.TestCase):
 
     def test_settings_merge_options1(self):
         options = CallOptions(timeout=46)
-        settings = CallSettings(timeout=9, page_descriptor=None, retry=None)
+        settings = _CallSettings(timeout=9, page_descriptor=None, retry=None)
         final = settings.merge(options)
         self.assertEqual(final.timeout, 46)
         self.assertIsNone(final.retry)
@@ -81,7 +81,7 @@ class TestCallSettings(unittest2.TestCase):
     def test_settings_merge_options2(self):
         retry = RetryOptions(None, None)
         options = CallOptions(retry=retry)
-        settings = CallSettings(
+        settings = _CallSettings(
             timeout=9, page_descriptor=None, retry=RetryOptions(None, None))
         final = settings.merge(options)
         self.assertEqual(final.timeout, 9)
@@ -92,8 +92,8 @@ class TestCallSettings(unittest2.TestCase):
         retry = RetryOptions(None, None)
         page_descriptor = object()
         options = CallOptions(timeout=46, page_token=INITIAL_PAGE)
-        settings = CallSettings(timeout=9, retry=retry,
-                                page_descriptor=page_descriptor)
+        settings = _CallSettings(timeout=9, retry=retry,
+                                 page_descriptor=page_descriptor)
         final = settings.merge(options)
         self.assertEqual(final.timeout, 46)
         self.assertEqual(final.page_descriptor, page_descriptor)
@@ -102,7 +102,7 @@ class TestCallSettings(unittest2.TestCase):
         self.assertEqual(final.retry, retry)
 
     def test_settings_merge_none(self):
-        settings = CallSettings(
+        settings = _CallSettings(
             timeout=23, page_descriptor=object(), bundler=object(),
             retry=object())
         final = settings.merge(None)


### PR DESCRIPTION
This allows any future renaming/revision not to be a breaking change.

Fixes #112 