### PR TITLE
Fix error-handling to use new gRPC exceptions

### DIFF
--- a/google/gax/__init__.py
+++ b/google/gax/__init__.py
@@ -33,7 +33,7 @@ from __future__ import absolute_import
 import collections
 
 
-__version__ = '0.13.0'
+__version__ = '0.14.0'
 
 
 INITIAL_PAGE = object()

--- a/google/gax/grpc.py
+++ b/google/gax/grpc.py
@@ -31,12 +31,11 @@
 
 from __future__ import absolute_import
 import grpc
-from grpc import StatusCode
-from grpc.framework.interfaces.face import face
+from grpc import RpcError, StatusCode
 from . import auth
 
 
-API_ERRORS = (face.AbortionError, )
+API_ERRORS = (RpcError, )
 """gRPC exceptions that indicate that an RPC was aborted."""
 
 
@@ -61,12 +60,13 @@ STATUS_CODE_NAMES = {
 
 def exc_to_code(exc):
     """Retrieves the status code from an exception"""
-    if not isinstance(exc, face.AbortionError):
+    if not isinstance(exc, RpcError):
         return None
-    elif isinstance(exc, face.ExpirationError):
-        return StatusCode.DEADLINE_EXCEEDED
     else:
-        return getattr(exc, 'code', None)
+        try:
+            return exc.code()
+        except AttributeError:
+            return None
 
 
 def _make_grpc_auth_func(auth_func):

--- a/test/test_grpc.py
+++ b/test/test_grpc.py
@@ -126,3 +126,16 @@ class TestCreateStub(unittest2.TestCase):
             _fake_create_stub, self.FAKE_SERVICE_PATH, self.FAKE_PORT,
             metadata_transformer=lambda x: tuple())
         self.assertFalse(auth.called)
+
+
+class TestErrors(unittest2.TestCase):
+    class MyError(grpc.RpcError):
+        def code(self):
+            return grpc.StatusCode.UNKNOWN
+
+    def test_exc_to_code(self):
+        code = grpc.exc_to_code(TestErrors.MyError())
+        self.assertEqual(code, grpc.StatusCode.UNKNOWN)
+        self.assertEqual(code, grpc.STATUS_CODE_NAMES['UNKNOWN'])
+        self.assertIsNone(grpc.exc_to_code(Exception))
+        self.assertIsNone(grpc.exc_to_code(grpc.RpcError()))


### PR DESCRIPTION
Previously, we were catching and wrapping AbortionError, which is no
longer used by gRPC. Instead, use RpcError.

/cc @dhermes

Fixes #129 and #130 