### PR TITLE
Wrap INVALID_ARGUMENT status as ValueError

### DIFF
--- a/google/gax/api_callable.py
+++ b/google/gax/api_callable.py
@@ -36,8 +36,8 @@ import time
 from future import utils
 
 from . import (BackoffSettings, BundleOptions, bundling, _CallSettings, config,
-               PageIterator, ResourceIterator, RetryOptions)
-from .errors import GaxError, RetryError
+               errors, PageIterator, ResourceIterator, RetryOptions)
+from .errors import RetryError
 
 _MILLIS_PER_SECOND = 1000
 
@@ -414,12 +414,12 @@ def construct_settings(
     return defaults
 
 
-def _catch_errors(a_func, errors):
+def _catch_errors(a_func, to_catch):
     """Updates a_func to wrap exceptions with GaxError
 
     Args:
         a_func (callable): A callable.
-        retry (list[Exception]): Configures the exceptions to wrap.
+        to_catch (list[Exception]): Configures the exceptions to wrap.
 
     Returns:
         A function that will wrap certain exceptions with GaxError
@@ -429,8 +429,9 @@ def _catch_errors(a_func, errors):
         try:
             return a_func(*args, **kwargs)
         # pylint: disable=catching-non-exception
-        except tuple(errors) as exception:
-            utils.raise_with_traceback(GaxError('RPC failed', cause=exception))
+        except tuple(to_catch) as exception:
+            utils.raise_with_traceback(
+                errors.create_error('RPC failed', cause=exception))
 
     return inner
 

--- a/google/gax/config.py
+++ b/google/gax/config.py
@@ -49,6 +49,10 @@ the client constants configuration for retrying into the correct gRPC objects.
 """
 
 
+NAME_STATUS_CODES = dict([(v, k) for (k, v) in STATUS_CODE_NAMES.items()])
+"""Inverse map for STATUS_CODE_NAMES"""
+
+
 create_stub = grpc.create_stub  # pylint: disable=invalid-name,
 """The function to use to create stubs."""
 

--- a/google/gax/config.py
+++ b/google/gax/config.py
@@ -49,7 +49,7 @@ the client constants configuration for retrying into the correct gRPC objects.
 """
 
 
-NAME_STATUS_CODES = dict([(v, k) for (k, v) in STATUS_CODE_NAMES.items()])
+NAME_STATUS_CODES = grpc.NAME_STATUS_CODES
 """Inverse map for STATUS_CODE_NAMES"""
 
 

--- a/google/gax/errors.py
+++ b/google/gax/errors.py
@@ -29,6 +29,9 @@
 
 """Provides GAX exceptions."""
 
+from __future__ import absolute_import
+from . import config
+
 
 class GaxError(Exception):
     """Common base class for exceptions raised by GAX.
@@ -49,6 +52,25 @@ class GaxError(Exception):
             return msg
 
         return 'GaxError({}, caused by {})'.format(msg, self.cause)
+
+
+def create_error(msg, cause=None):
+    """Creates an error.
+
+    Uses a Python built-in exception if one is available, and a
+    GaxError otherwise.
+
+    Attributes:
+      msg (string): describes the error that occurred.
+      cause (Exception, optional): the exception raised by a lower
+        layer of the RPC stack (for example, gRPC) that caused this
+        exception, or None if this exception originated in GAX.
+    """
+    if config.NAME_STATUS_CODES.get(
+            config.exc_to_code(cause)) == 'INVALID_ARGUMENT':
+        return ValueError('{}: {}'.format(msg, cause))
+    else:
+        return GaxError(msg, cause)
 
 
 class RetryError(GaxError):

--- a/google/gax/grpc.py
+++ b/google/gax/grpc.py
@@ -58,6 +58,10 @@ STATUS_CODE_NAMES = {
 """Maps strings used in client config to gRPC status codes."""
 
 
+NAME_STATUS_CODES = dict([(v, k) for (k, v) in STATUS_CODE_NAMES.items()])
+"""Inverse map for STATUS_CODE_NAMES"""
+
+
 def exc_to_code(exc):
     """Retrieves the status code from an exception"""
     if not isinstance(exc, RpcError):

--- a/test/test_api_callable.py
+++ b/test/test_api_callable.py
@@ -38,6 +38,7 @@ from google.gax import (
     api_callable, bundling, BackoffSettings, BundleDescriptor, BundleOptions,
     _CallSettings, CallOptions, INITIAL_PAGE, PageDescriptor, RetryOptions)
 from google.gax.errors import GaxError, RetryError
+import grpc
 
 
 _SERVICE_NAME = 'test.interface.v1.api'
@@ -484,3 +485,15 @@ class TestCreateApiCallable(unittest2.TestCase):
         other_error_callable = api_callable.create_api_call(
             other_error_func, _CallSettings())
         self.assertRaises(AnotherException, other_error_callable, None)
+
+    def test_wrap_value_error(self):
+
+        invalid_attribute_exc = grpc.RpcError()
+        invalid_attribute_exc.code = lambda: grpc.StatusCode.INVALID_ARGUMENT
+
+        def value_error_func(*dummy_args, **dummy_kwargs):
+            raise invalid_attribute_exc
+
+        value_error_callable = api_callable.create_api_call(
+            value_error_func, _CallSettings())
+        self.assertRaises(ValueError, value_error_callable, None)


### PR DESCRIPTION
Fixes #123

The second part of this is to modify GAPIC (in the `toolkit` repo) so that all API call methods that take arguments specify in the docstring that they may raise `ValueError`. This is done at https://github.com/googleapis/toolkit/pull/491.