### PR TITLE
Add logging.NullHandler

### DIFF
--- a/google/gax/__init__.py
+++ b/google/gax/__init__.py
@@ -44,6 +44,7 @@ from google.gax.retry import retryable
 __version__ = '0.15.1'
 
 
+logging.basicConfig()
 _LOG = logging.getLogger(__name__)
 
 

--- a/google/gax/__init__.py
+++ b/google/gax/__init__.py
@@ -44,8 +44,8 @@ from google.gax.retry import retryable
 __version__ = '0.15.1'
 
 
-logging.basicConfig()
 _LOG = logging.getLogger(__name__)
+_LOG.addHandler(logging.NullHandler())
 
 
 _MILLIS_PER_SEC = 1000

--- a/google/gax/__init__.py
+++ b/google/gax/__init__.py
@@ -41,7 +41,7 @@ from google.gax.errors import GaxError
 from google.gax.retry import retryable
 
 
-__version__ = '0.15.0'
+__version__ = '0.15.1'
 
 
 _LOG = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes "No handlers found for logger google.gax" error