### PR TITLE
Re-raise unrecognized exceptions on retry.

### DIFF
--- a/google/gax/retry.py
+++ b/google/gax/retry.py
@@ -120,10 +120,11 @@ def retryable(a_func, retry_options, **kwargs):
                 return to_call(*args)
             except Exception as exception:  # pylint: disable=broad-except
                 code = config.exc_to_code(exception)
+
+                # Do not be greedy; if this is an exception that we do
+                # not know for sure should be retried, simply re-raise it.
                 if code not in retry_options.retry_codes:
-                    raise errors.RetryError(
-                        'Exception occurred in retry method that was not'
-                        ' classified as transient', exception)
+                    raise
 
                 # pylint: disable=redefined-variable-type
                 exc = errors.RetryError(


### PR DESCRIPTION
Right now, if our retry logic encounters an exception it does not recognize, it raises `RetryError` which wraps the original exception.

This probably is not what we want. The end result is that the `RetryError` will end up [masking the actual exception][1] that needs to be fixed. The developer can still get at it (by calling `.cause.exception()`), but that is not clear or documented anywhere and there is no intuitive reason to try it.

I assert that it would be better to just raise the original exception, in the original context, and reserve `RetryError` for errors that the retry logic fundamentally understands the nature of (e.g. hitting the max retry limit).

If accepted, this PR:

  * Fixes GoogleCloudPlatform/google-cloud-python#3083
  * Closes GoogleCloudPlatform/google-cloud-python#3087 (as no longer necessary)

  [1]: https://github.com/GoogleCloudPlatform/python-docs-samples/issues/833