### PR TITLE
Fix packaging setup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,4 @@
-include LICENSE
-include README.rst
-global-include *.json
-graft google
-exclude tests
-global-exclude *.pyc __pycache__
+include LICENSE README.rst
+recursive-include google *.json
+recursive-include tests *
+global-exclude __pycache__ *.pyc

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import io
+
 from setuptools import find_packages
 from setuptools import setup
 
@@ -43,7 +45,7 @@ DEPENDENCIES = [
     'protobuf>=3.0.0, <4.0dev',
 ]
 
-with open('README.rst', 'r') as readme:
+with io.open('README.rst', 'r') as readme:
     long_description = readme.read()
 
 setup(
@@ -54,9 +56,8 @@ setup(
     author='Google API Authors',
     author_email='googleapis-packages@google.com',
     url='https://github.com/googleapis/gax-python',
+    packages=find_packages(exclude=('tests*',)),
     namespace_packages=('google',),
-    packages=find_packages(exclude=('tests',)),
-    package_dir={'google-gax': 'google'},
     license='BSD-3-Clause',
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
* Don't include tests in the binary (wheel) distribution.
* Include tests in the source distribution.
* Remove (seemingly?) unneeded package_dir.
* Use io.open over open for proper encoding.