### PR TITLE
Fix x-goog-api-client header inconsistency for spanner client

### DIFF
--- a/tests/test_api_callable.py
+++ b/tests/test_api_callable.py
@@ -141,6 +141,18 @@ class TestCreateApiCallable(unittest2.TestCase):
         self.assertEqual(my_callable(None, CallOptions(key='updated')),
                          'updated')
 
+    def test_call_merge_options_metadata(self):
+        this_kwargs = {'key': 'value', 'metadata':
+                       [('key1', 'val1'), ('key2', 'val2')]}
+        settings = _CallSettings(kwargs=this_kwargs)
+        my_callable = api_callable.create_api_call(
+            lambda _req, _timeout, **kwargs: kwargs, settings)
+        self.assertEqual(my_callable(None), this_kwargs)
+        this_kwargs['metadata'] = [('key1', 'updated_val1'), ('key2', 'val2')]
+        self.assertEqual(
+            my_callable(None, CallOptions(metadata=[('key1', 'updated_val1')])),
+            this_kwargs)
+
     @mock.patch('time.time')
     @mock.patch('google.gax.config.exc_to_code')
     def test_retry(self, mock_exc_to_code, mock_time):

--- a/tests/test_api_callable.py
+++ b/tests/test_api_callable.py
@@ -142,16 +142,25 @@ class TestCreateApiCallable(unittest2.TestCase):
                          'updated')
 
     def test_call_merge_options_metadata(self):
-        this_kwargs = {'key': 'value', 'metadata':
-                       [('key1', 'val1'), ('key2', 'val2')]}
-        settings = _CallSettings(kwargs=this_kwargs)
+        settings_kwargs = {
+            'key': 'value',
+            'metadata': [('key1', 'val1'), ('key2', 'val2')]
+        }
+
+        settings = _CallSettings(kwargs=settings_kwargs)
         my_callable = api_callable.create_api_call(
             lambda _req, _timeout, **kwargs: kwargs, settings)
-        self.assertEqual(my_callable(None), this_kwargs)
-        this_kwargs['metadata'] = [('key1', 'updated_val1'), ('key2', 'val2')]
+
+        expected_kwargs = settings_kwargs
+        self.assertEqual(my_callable(None), expected_kwargs)
+
+        expected_kwargs = {
+            'key': 'value',
+            'metadata': [('key1', 'updated_val1'), ('key2', 'val2')]
+        }
         self.assertEqual(
             my_callable(None, CallOptions(metadata=[('key1', 'updated_val1')])),
-            this_kwargs)
+            expected_kwargs)
 
     @mock.patch('time.time')
     @mock.patch('google.gax.config.exc_to_code')

--- a/tests/test_api_callable.py
+++ b/tests/test_api_callable.py
@@ -173,7 +173,7 @@ class TestCreateApiCallable(unittest2.TestCase):
             my_callable(None, CallOptions(metadata=[('key3', 'val3')])),
             expected_kwargs)
 
-        # Do all: add a new key and override an existing one in in
+        # Do all: add a new key and override an existing one in
         # settings.kwargs['metadata']
         expected_kwargs = {
             'key': 'value',

--- a/tests/test_api_callable.py
+++ b/tests/test_api_callable.py
@@ -151,15 +151,37 @@ class TestCreateApiCallable(unittest2.TestCase):
         my_callable = api_callable.create_api_call(
             lambda _req, _timeout, **kwargs: kwargs, settings)
 
+        # Merge empty options, settings.kwargs['metadata'] remain unchanged
         expected_kwargs = settings_kwargs
         self.assertEqual(my_callable(None), expected_kwargs)
 
+        # Override an existing key in settings.kwargs['metadata']
         expected_kwargs = {
             'key': 'value',
-            'metadata': [('key1', 'updated_val1'), ('key2', 'val2')]
+            'metadata': [('key1', '_val1'), ('key2', 'val2')]
         }
         self.assertEqual(
-            my_callable(None, CallOptions(metadata=[('key1', 'updated_val1')])),
+            my_callable(None, CallOptions(metadata=[('key1', '_val1')])),
+            expected_kwargs)
+
+        # Add a new key in settings.kwargs['metadata']
+        expected_kwargs = {
+            'key': 'value',
+            'metadata': [('key3', 'val3'), ('key1', 'val1'), ('key2', 'val2')]
+        }
+        self.assertEqual(
+            my_callable(None, CallOptions(metadata=[('key3', 'val3')])),
+            expected_kwargs)
+
+        # Do all: add a new key and override an existing one in in
+        # settings.kwargs['metadata']
+        expected_kwargs = {
+            'key': 'value',
+            'metadata': [('key3', 'val3'), ('key2', '_val2'), ('key1', 'val1')]
+        }
+        self.assertEqual(
+            my_callable(None, CallOptions(
+                metadata=[('key3', 'val3'), ('key2', '_val2')])),
             expected_kwargs)
 
     @mock.patch('time.time')


### PR DESCRIPTION
Merges tuples in settings.kwargs['metadata'] propertly. For example for the input of:

```python
options.kwargs = {metadata: [('x-goog-api-client', 'val1')]}
settings.kwargs = {metadata: [('google-cloud-resource-prefix', 'val2'), ('x-goog-api-client', 'val3')]}
```
The merged result will be:
```python
this_settings.kwargs = {metadata: [('x-goog-api-client', 'val1'), ('google-cloud-resource-prefix', 'val2')]}
```